### PR TITLE
Add LearningObjective support to Python SDK

### DIFF
--- a/epistemic_me/dialectic.py
+++ b/epistemic_me/dialectic.py
@@ -1,11 +1,31 @@
 from . import config
 from .generated.proto.models import dialectic_pb2
+from .generated.proto.models import beliefs_pb2
+from typing import List, Optional
+
+class LearningObjective:
+    def __init__(self, description: str, topics: List[str], target_belief_type: beliefs_pb2.BeliefType):
+        self.description = description
+        self.topics = topics
+        self.target_belief_type = target_belief_type
+
+    def to_proto(self) -> dialectic_pb2.LearningObjective:
+        return dialectic_pb2.LearningObjective(
+            description=self.description,
+            topics=self.topics,
+            target_belief_type=self.target_belief_type
+        )
 
 class Dialectic:
     @classmethod
-    def create(cls, self_model_id: str):
-        """Creates a new dialectic session"""
-        return config.grpc_client.create_dialectic(self_model_id)
+    def create(cls, self_model_id: str, learning_objective: Optional[LearningObjective] = None, 
+               dialectic_type: dialectic_pb2.DialecticType = dialectic_pb2.DialecticType.DEFAULT):
+        """Creates a new dialectic session with an optional learning objective"""
+        return config.grpc_client.create_dialectic(
+            self_model_id, 
+            learning_objective=learning_objective,
+            dialectic_type=dialectic_type
+        )
 
     @classmethod
     def update(cls, id: str, answer: str, self_model_id: str):

--- a/epistemic_me/grpc_client.py
+++ b/epistemic_me/grpc_client.py
@@ -1,9 +1,12 @@
 import grpc
 from google.protobuf.json_format import MessageToDict
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional, TYPE_CHECKING
 
 from .generated.proto import epistemic_me_pb2, epistemic_me_pb2_grpc
 from .generated.proto.models import dialectic_pb2
+
+if TYPE_CHECKING:
+    from .dialectic import LearningObjective
 
 class GrpcClient:
     def __init__(self, base_url: str, api_key: str):
@@ -70,9 +73,12 @@ class GrpcClient:
         response = self.stub.AddPhilosophy(request, metadata=self._get_metadata())
         return MessageToDict(response)
 
-    def create_dialectic(self, id: str):
+    def create_dialectic(self, id: str, learning_objective: Optional['LearningObjective'] = None,
+                        dialectic_type: dialectic_pb2.DialecticType = dialectic_pb2.DialecticType.DEFAULT):
         request = self.pb.CreateDialecticRequest(
-            self_model_id=id
+            self_model_id=id,
+            dialectic_type=dialectic_type,
+            learning_objective=learning_objective.to_proto() if learning_objective else None
         )
         response = self.stub.CreateDialectic(request, metadata=self._get_metadata())
         return MessageToDict(response)


### PR DESCRIPTION
The PR adds a Learning Objective to a Dialectic. It is intended to move the SDK towards a modality of Dialectic design where the Developer can specify what they want to learn about their users, and then train a Question-Answer Dialectic to ask questions of their user until the LearningObjective for the dialectic is complete.

The Learning Objective can specify the BeliefType it needs to collect in order to fulfill he learning specification of the Dialectic.